### PR TITLE
Explicitly set the java toolchain and release version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Set up JDK
               uses: actions/setup-java@v5
               with:
-                  java-version: '17'
+                  java-version: '25'
                   distribution: 'corretto'
 
             - name: Setup Gradle

--- a/buildSrc/src/main/kotlin/api-models-aws.model-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/api-models-aws.model-conventions.gradle.kts
@@ -43,6 +43,16 @@ sourceSets {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.release.set(8)
+}
+
 tasks {
     build {
         mustRunAfter(clean)


### PR DESCRIPTION
Please read the [Contributing Guidelines](CONTRIBUTING.md) before submitting a
pull request. We cannot accept pull requests against the generated models in
this repository

## Describe your changes

  Without these settings, the Java version declared in Gradle module metadata depends on whatever `JAVA_HOME` happens to be set on the release machine. This affects consumers that use Gradle's JVM version compatibility checking during dependency resolution.                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
  For example, `s3` version [1.0.16](https://repo1.maven.org/maven2/software/amazon/api/models/s3/1.0.16/s3-1.0.16.module) declares `org.gradle.jvm.version: 25`, which breaks consumers like [smithy-java](https://github.com/smithy-lang/smithy-java) that run on JDK 21. Version [1.0.17](https://repo1.maven.org/maven2/software/amazon/api/models/s3/1.0.17/s3-1.0.17.module) declares JDK 17, presumably because the release host had a different `JAVA_HOME`. Since these jars only  contain Smithy JSON models and no bytecode, the declared JVM version is irrelevant to actual compatibility but Gradle enforces it regardless. I changed it to 8 to maximize compatibility. 

## Link to the relevant issue(s)

## Checklist
- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I confirm that this pull request is not against the generated models.
- [x] My contribution is licensed under the [Apache-2.0 license](LICENSE).
